### PR TITLE
Fix missing status bar

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,17 +35,17 @@
   },
   "devDependencies": {
     "rimraf": "~2.6.2",
-    "typedoc": "~0.12.0",
-    "typescript": "~3.7.1",
-    "css-loader": "~0.28.7",
-    "mini-css-extract-plugin": "~0.4.4",
-    "svgo": "~1.0.4",
-    "svg-url-loader": "~2.3.1",
-    "svgo-loader": "~2.1.0",
-    "url-loader": "~1.0.1",
+    "typedoc": "~0.22.18",
+    "typescript": "~4.1.3",
+    "css-loader": "~3.6.0",
+    "mini-css-extract-plugin": "~0.11.3",
+    "svgo": "~2.8.0",
+    "svg-url-loader": "~7.1.1",
+    "svgo-loader": "~3.0.3",
+    "url-loader": "~4.1.1",
     "watch": "~1.0.2",
-    "webpack": "~4.12.0",
-    "webpack-cli": "^3.0.3"
+    "webpack": "~5.75.0",
+    "webpack-cli": "^4.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/style/variables.css
+++ b/style/variables.css
@@ -352,6 +352,10 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-toolbar-header-margin: 4px 4px 0px 4px;
   --jp-toolbar-active-background: var(--md-grey-300);
 
+  /* Statusbar specific styles */
+
+  --jp-statusbar-height: 24px;
+
   /* Input field styles */
 
   --jp-input-box-shadow: inset 0 0 2px var(--md-blue-300);


### PR DESCRIPTION
JupyterLab 3.4 introduced new css variable --jp-statusbar-height. Themes created from older theme-cookiecutter missed it and statusbar is not shown in the UI. 